### PR TITLE
Add nickname input and small setup page before game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hangman-game",
       "version": "0.0.0",
       "dependencies": {
+        "@vueuse/core": "^12.5.0",
         "axios": "^1.7.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2469,23 +2470,34 @@
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
-      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.5.0.tgz",
+      "integrity": "sha512-GVyH1iYqNANwcahAx8JBm6awaNgvR/SwZ1fjr10b8l1HIgDp82ngNbfzJUgOgWEoxjL+URAggnlilAEXwCOZtg==",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.11.1",
-        "@vueuse/shared": "10.11.1",
-        "vue-demi": ">=0.14.8"
+        "@vueuse/metadata": "12.5.0",
+        "@vueuse/shared": "12.5.0",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/@vueuse/shared": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.5.0.tgz",
+      "integrity": "sha512-vMpcL1lStUU6O+kdj6YdHDixh0odjPAUM15uJ9f7MY781jcYkIwFA4iv2EfoIPO6vBmvutI1HxxAwmf0cx5ISQ==",
+      "dependencies": {
+        "vue": "^3.5.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
-      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.5.0.tgz",
+      "integrity": "sha512-Ui7Lo2a7AxrMAXRF+fAp9QsXuwTeeZ8fIB9wsLHqzq9MQk+2gMYE2IGJW48VMJ8ecvCB3z3GsGLKLbSasQ5Qlg==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -5299,6 +5311,28 @@
       },
       "peerDependencies": {
         "vue": ">= 3.2.0"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/radix-vue/node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/radix-vue/node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@vueuse/core": "^12.5.0",
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { useGameStore } from '@/stores/game.ts'
 
-const game = useGameStore();
+const game = useGameStore()
 </script>
 
 <template>
@@ -12,7 +12,10 @@ const game = useGameStore();
       <Button>
         <router-link to="/">&lt; Home</router-link>
       </Button>
-      <Badge>{{game.difficulty}}</Badge>
+      <div class="flex items-center justify-center gap-2">
+        <p>{{game.nickname}} playing a game on</p>
+        <Badge>{{ game.difficulty }}</Badge>
+      </div>
     </div>
   </nav>
 </template>

--- a/src/components/ui/input/Input.vue
+++ b/src/components/ui/input/Input.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+import { useVModel } from '@vueuse/core'
+
+const props = defineProps<{
+  defaultValue?: string | number
+  modelValue?: string | number
+  class?: HTMLAttributes['class']
+}>()
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', payload: string | number): void
+}>()
+
+const modelValue = useVModel(props, 'modelValue', emits, {
+  passive: true,
+  defaultValue: props.defaultValue,
+})
+</script>
+
+<template>
+  <input v-model="modelValue" :class="cn('flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50', props.class)">
+</template>

--- a/src/components/ui/input/index.ts
+++ b/src/components/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input.vue'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import GameView from '@/views/GameView.vue'
+import StartGameView from '@/views/StartGameView.vue'
 import ScoreboardView from '@/views/ScoreboardView.vue'
 
 const router = createRouter({
@@ -10,6 +11,11 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView,
+    },
+    {
+      path: '/start',
+      name: 'start',
+      component: StartGameView,
     },
     {
       path: '/game',

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -10,6 +10,7 @@ import type { Score } from '@/types/score.ts'
 
 export const useGameStore = defineStore('game', {
   state: () => ({
+    nickname: '',
     word: '',
     wordMeaning: '',
     correctLetters: [] as string[],

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -14,7 +14,7 @@ import hangman from "@/assets/hangman.svg"
 
     <nav class="flex flex-col gap-4">
       <Button>
-        <router-link to="/game" class="btn btn-primary">Start Game</router-link>
+        <router-link to="/start" class="btn btn-primary">Start Game</router-link>
       </Button>
       <SettingsDialog/>
       <Button>

--- a/src/views/StartGameView.vue
+++ b/src/views/StartGameView.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Input } from '@/components/ui/input'
+import { Difficulty } from '@/types/difficulty.enum.ts'
+import { Button } from '@/components/ui/button'
+import { useGameStore } from '@/stores/game.ts'
+
+const game = useGameStore()
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center h-full gap-2">
+    <h1 class="text-center font-bold text-4xl mb-2">Configure Game</h1>
+    <h2>Choose a nickname:</h2>
+    <Input class="w-1/3" placeholder="HangmanProfi123" v-model="game.nickname" />
+    <h2>Select difficulty</h2>
+    <div>
+      <Button
+        v-for="difficulty in Object.values(Difficulty)"
+        :key="difficulty"
+        variant="outline"
+        class="mr-2 font-semibold hover:border-green-700"
+        :class="{
+          'text-white hover:text-white  border-green-700 bg-green-700 hover:bg-green-700':
+            game.difficulty == difficulty,
+        }"
+        @click="game.setDifficulty(difficulty)"
+      >
+        {{ difficulty.charAt(0).toUpperCase() + difficulty.slice(1) }}
+      </Button>
+    </div>
+    <router-link to="/game" class="mt-12">
+      <Button>Start Game</Button>
+    </router-link>
+  </div>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
Quick and dirty integration of a small setup page with nickname input

"Start game" on the homepage now links to "/start" which is a small setup page that lets the user choose a nickname (which is for now stored in the gamestore) and again select the difficulty. From there the user is taken to the actual gameboard

**Final stylings still missing!!**